### PR TITLE
INT_SH_M-1370: Remove client IP address from JSON response

### DIFF
--- a/go/src/restincl/workerpool.go
+++ b/go/src/restincl/workerpool.go
@@ -713,6 +713,10 @@ func genRsp(ac *atmi.ATMICtx, buf atmi.TypedBuffer, svc *ServiceMap,
 						header = obj["Header"].(map[string]interface{})
 						delete(obj, "Header")
 					}
+
+					// Remove address field from response JSON.
+					delete(obj, "RemoteAddr")
+
 					//Add headers to ResponseWriter
 					for k, v := range header {
 						for _, val := range v.([]interface{}) {


### PR DESCRIPTION
Remove _RemoteAddr_ field from response JSON similar to _Cookie_ and _Header_ because it is intended only for internal use.