### PR TITLE
fix:INT_SH_M-2165 - Adding check for json type cast

### DIFF
--- a/go/src/restincl/workerpool.go
+++ b/go/src/restincl/workerpool.go
@@ -1266,7 +1266,11 @@ func handleMessage(ac *atmi.ATMICtx, svc *ServiceMap, w http.ResponseWriter,
 					ac.TpLogError("Failed to unmarshal JSON: %v", err.Error())
 					return atmi.FAIL
 				}*/
-				obj := jsonObj.(map[string]interface{})
+				obj, ok := jsonObj.(map[string]interface{})
+				if !ok {
+					ac.TpLogError("Expected JSON object, but got %T", jsonObj)
+					return atmi.FAIL
+				}
 
 				//Add URL to JSON
 				if svc.Format == "r" || svc.Format == "regexp" {


### PR DESCRIPTION
Otherwise we can make restincl unusable by flooding it with data, which is parsed as a different type and can not be cast as 'map[string]interface{}'. If the request count matches the worker count, there are no free workers anymore as they get stuck.